### PR TITLE
Missing traits for serialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,15 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  # Mimics the setup of docs.rs, but fails on warnings
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          profile: minimal
+      - run: env RUSTDOCFLAGS='--cfg docsrs -D warnings' cargo doc --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Cargo.lock
 /target
 *.sublime-project
 *.sublime-workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ecdsa = { version = "0.16", default-features = false, features = ["signing", "ve
 sha2 = { version = "0.10", default-features = false }
 
 # Optional dependencies
-serde = { version = "1", optional = true, default-features = false }
+serde = { version = "1", optional = true, default-features = false, features = ["serde_derive"] }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,8 @@ rust-version = "1.79"
 [dependencies]
 primeorder = { version = "0.13", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-ecdsa = { version = "0.16", default-features = false, features = ["arithmetic", "digest", "hazmat"] }
+ecdsa = { version = "0.16", default-features = false, features = ["signing", "verifying"] }
 sha2 = { version = "0.10", default-features = false }
-
 
 # Optional dependencies
 serde = { version = "1", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,18 @@ num-traits = { version = "0.2", default-features = false }
 ecdsa = { version = "0.16", default-features = false, features = ["arithmetic", "digest", "hazmat"] }
 sha2 = { version = "0.10", default-features = false }
 
+
+# Optional dependencies
+serde = { version = "1", optional = true, default-features = false }
+
 [dev-dependencies]
 criterion = "0.5"
 rand_core = { version = "0.6", features = ["getrandom"] }
 k256 = "0.13"
 proptest = "1"
+
+[features]
+serde = ["ecdsa/serde", "primeorder/serde", "dep:serde"]
 
 [[bench]]
 bench = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ proptest = "1"
 
 [features]
 serde = ["ecdsa/serde", "primeorder/serde", "dep:serde"]
+pkcs8 = ["ecdsa/pkcs8"]
 
 [[bench]]
 bench = true

--- a/src/curve16.rs
+++ b/src/curve16.rs
@@ -1,13 +1,11 @@
 use primeorder::{
-    elliptic_curve::{
-        bigint::U64, generic_array::typenum, Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding,
-    },
+    elliptic_curve::{Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding},
     point_arithmetic::EquationAIsMinusThree,
     AffinePoint, PrimeCurve, PrimeCurveParams, ProjectivePoint,
 };
 
 use crate::{
-    prime_field::FieldElement,
+    prime_field::{FieldElement, ReprSizeTypenum, ReprUint},
     traits::{Modulus, PrimeFieldConstants},
 };
 
@@ -47,8 +45,8 @@ impl PrimeFieldConstants<u16> for Modulus<u16, ORDER> {
 pub struct TinyCurve16;
 
 impl Curve for TinyCurve16 {
-    type FieldBytesSize = typenum::U8;
-    type Uint = U64;
+    type FieldBytesSize = ReprSizeTypenum;
+    type Uint = ReprUint;
     const ORDER: Self::Uint = Self::Uint::from_u64(ORDER);
 }
 
@@ -76,13 +74,14 @@ impl PrimeCurveParams for TinyCurve16 {
 
 #[cfg(test)]
 mod tests {
-    use super::TinyCurve16;
     use primeorder::elliptic_curve::{
-        bigint::U64,
         ops::{MulByGenerator, Reduce},
         CurveArithmetic, ProjectivePoint,
     };
     use proptest::prelude::*;
+
+    use super::TinyCurve16;
+    use crate::prime_field::ReprUint;
 
     type Scalar = <TinyCurve16 as CurveArithmetic>::Scalar;
     type Point = ProjectivePoint<TinyCurve16>;
@@ -90,7 +89,7 @@ mod tests {
     prop_compose! {
         /// Generate a random odd modulus.
         fn scalar()(n in any::<u64>()) -> Scalar {
-            Scalar::reduce(U64::from(n))
+            Scalar::reduce(ReprUint::from(n))
         }
     }
 

--- a/src/curve32.rs
+++ b/src/curve32.rs
@@ -1,13 +1,11 @@
 use primeorder::{
-    elliptic_curve::{
-        bigint::U64, generic_array::typenum, Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding,
-    },
+    elliptic_curve::{Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding},
     point_arithmetic::EquationAIsMinusThree,
     AffinePoint, PrimeCurve, PrimeCurveParams, ProjectivePoint,
 };
 
 use crate::{
-    prime_field::FieldElement,
+    prime_field::{FieldElement, ReprSizeTypenum, ReprUint},
     traits::{Modulus, PrimeFieldConstants},
 };
 
@@ -47,8 +45,8 @@ impl PrimeFieldConstants<u32> for Modulus<u32, ORDER> {
 pub struct TinyCurve32;
 
 impl Curve for TinyCurve32 {
-    type FieldBytesSize = typenum::U8;
-    type Uint = U64;
+    type FieldBytesSize = ReprSizeTypenum;
+    type Uint = ReprUint;
     const ORDER: Self::Uint = Self::Uint::from_u64(ORDER);
 }
 
@@ -76,13 +74,14 @@ impl PrimeCurveParams for TinyCurve32 {
 
 #[cfg(test)]
 mod tests {
-    use super::TinyCurve32;
     use primeorder::elliptic_curve::{
-        bigint::U64,
         ops::{MulByGenerator, Reduce},
         CurveArithmetic, ProjectivePoint,
     };
     use proptest::prelude::*;
+
+    use super::TinyCurve32;
+    use crate::prime_field::ReprUint;
 
     type Scalar = <TinyCurve32 as CurveArithmetic>::Scalar;
     type Point = ProjectivePoint<TinyCurve32>;
@@ -90,7 +89,7 @@ mod tests {
     prop_compose! {
         /// Generate a random odd modulus.
         fn scalar()(n in any::<u64>()) -> Scalar {
-            Scalar::reduce(U64::from(n))
+            Scalar::reduce(ReprUint::from(n))
         }
     }
 

--- a/src/curve64.rs
+++ b/src/curve64.rs
@@ -1,13 +1,11 @@
 use primeorder::{
-    elliptic_curve::{
-        bigint::U64, generic_array::typenum, Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding,
-    },
+    elliptic_curve::{Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding},
     point_arithmetic::EquationAIsMinusThree,
     AffinePoint, PrimeCurve, PrimeCurveParams, ProjectivePoint,
 };
 
 use crate::{
-    prime_field::FieldElement,
+    prime_field::{FieldElement, ReprSizeTypenum, ReprUint},
     traits::{Modulus, PrimeFieldConstants},
 };
 
@@ -47,8 +45,8 @@ impl PrimeFieldConstants<u64> for Modulus<u64, ORDER> {
 pub struct TinyCurve64;
 
 impl Curve for TinyCurve64 {
-    type FieldBytesSize = typenum::U8;
-    type Uint = U64;
+    type FieldBytesSize = ReprSizeTypenum;
+    type Uint = ReprUint;
     const ORDER: Self::Uint = Self::Uint::from_u64(ORDER);
 }
 
@@ -76,13 +74,14 @@ impl PrimeCurveParams for TinyCurve64 {
 
 #[cfg(test)]
 mod tests {
-    use super::TinyCurve64;
     use primeorder::elliptic_curve::{
-        bigint::U64,
         ops::{MulByGenerator, Reduce},
         CurveArithmetic, ProjectivePoint,
     };
     use proptest::prelude::*;
+
+    use super::TinyCurve64;
+    use crate::prime_field::ReprUint;
 
     type Scalar = <TinyCurve64 as CurveArithmetic>::Scalar;
     type Point = ProjectivePoint<TinyCurve64>;
@@ -90,7 +89,7 @@ mod tests {
     prop_compose! {
         /// Generate a random odd modulus.
         fn scalar()(n in any::<u64>()) -> Scalar {
-            Scalar::reduce(U64::from(n))
+            Scalar::reduce(ReprUint::from(n))
         }
     }
 

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -4,10 +4,14 @@ use ecdsa::{
 };
 use primeorder::{
     elliptic_curve::{
-        generic_array::ArrayLength, ops::Reduce, CurveArithmetic, FieldBytes, PrimeCurve,
+        generic_array::ArrayLength, ops::Reduce, point::PointCompression, CurveArithmetic,
+        FieldBytes, PrimeCurve,
     },
     AffinePoint, PrimeField,
 };
+
+#[cfg(feature = "pkcs8")]
+use primeorder::elliptic_curve::pkcs8::{AssociatedOid, ObjectIdentifier};
 
 use crate::{
     curve16::TinyCurve16,
@@ -46,6 +50,33 @@ impl DigestPrimitive for TinyCurve32 {
 
 impl DigestPrimitive for TinyCurve64 {
     type Digest = TinyHash<8>;
+}
+
+impl PointCompression for TinyCurve16 {
+    const COMPRESS_POINTS: bool = true;
+}
+
+impl PointCompression for TinyCurve32 {
+    const COMPRESS_POINTS: bool = true;
+}
+
+impl PointCompression for TinyCurve64 {
+    const COMPRESS_POINTS: bool = true;
+}
+
+#[cfg(feature = "pkcs8")]
+impl AssociatedOid for TinyCurve16 {
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.4.1.202767.1");
+}
+
+#[cfg(feature = "pkcs8")]
+impl AssociatedOid for TinyCurve32 {
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.4.1.202767.2");
+}
+
+#[cfg(feature = "pkcs8")]
+impl AssociatedOid for TinyCurve64 {
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.4.1.202767.3");
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@
 //! ## `serde` support
 //!
 //! When the `serde` feature of this crate is enabled, `Serialize` and
-//! `Deserialize` are impl'd for [`FieldElement`].
+//! `Deserialize` are impl'd for the associated
+//! [`CurveArithmetic::Scalar`](primeorder::elliptic_curve::CurveArithmetic::Scalar)
+//! types of the curves.
 
 mod curve16;
 mod curve32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,11 @@
 )]
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
+//! ## `serde` support
+//!
+//! When the `serde` feature of this crate is enabled, `Serialize` and
+//! `Deserialize` are impl'd for [`FieldElement`].
+
 mod curve16;
 mod curve32;
 mod curve64;

--- a/src/prime_field.rs
+++ b/src/prime_field.rs
@@ -23,6 +23,7 @@ use crate::{
 };
 
 #[derive(Default, Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FieldElement<T: PrimitiveUint, const M: u64>(T);
 
 impl<T, const M: u64> FieldElement<T, M>

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -8,15 +8,7 @@ use primeorder::elliptic_curve::subtle::{ConditionallySelectable, ConstantTimeEq
 use crate::reciprocal::{rem_wide_with_reciprocal, Reciprocal};
 
 pub trait PrimeFieldConstants<T> {
-    type Repr: AsRef<[u8]>
-        + AsMut<[u8]>
-        + Send
-        + Sync
-        + Default
-        + Clone
-        + Copy
-        + From<[u8; 8]>
-        + Into<[u8; 8]>;
+    type Repr: AsRef<[u8]> + AsMut<[u8]> + Send + Sync + Default + Clone + Copy;
     const MODULUS_STR: &'static str;
     const MODULUS: T;
     const NUM_BITS: u32;


### PR DESCRIPTION
In order for `ecdsa::VerifyingKey` to be `Serialize` (see [here](https://github.com/RustCrypto/signatures/blob/master/ecdsa/src/verifying.rs#L457)) there are a few (somewhat odd) traits required:

- pkcs8::AssociatedOid
- elliptic_curve::PointCompression

For the first, we'd need a proper PEN code for the OID. The one used here, 202767, is just a random number.

Apply for a PEN here: https://www.iana.org/assignments/enterprise-numbers/assignment/apply/
Currently assigned OIDs: https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers

Implementing this trait also adds a `pkcs8` feature which is unfortunate but inevitable.

As for `PointCompression` I believe that most modern curves prefer to use compression. It's unclear to me why this choice is exposed as a separate trait but it seems easy enough to impl.

*NOTE*: in the next version of `ecdsa` the `pem` feature requirement is gone, but for the latest stable `Serialize` is feature-gated behind both `serde` and `pem` (see [here](https://github.com/RustCrypto/signatures/blob/ecdsa/v0.16.9/ecdsa/src/verifying.rs#L454)).

*NOTE-2*: Unclear to me why the git history is such a mess, the relevant commit here is only https://github.com/dvdplm/tiny-curve/pull/2/commits/42c714627d241117cdd6a17c663bbb956e5149ff
